### PR TITLE
Update ads.txt for Connatix

### DIFF
--- a/MediaImpact/autobild.de/ads.txt
+++ b/MediaImpact/autobild.de/ads.txt
@@ -51,6 +51,34 @@ risecodes.com,6022acddc8b2f90001767980, RESELLER
 yahoo.com, 59040, RESELLER, e1a5b5b6e3255540
 emxdgt.com, 2014, RESELLER, 1e1d41537f7cad7f
 
+#accompanying-content #Video
+connatix.com, 1428082215386231, DIRECT, 2af98acdee0e81ed
+pubmatic.com, 156592, RESELLER, 5d62403b186f2ace
+pubmatic.com, 163106, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 19564, RESELLER, 0bfd66d529a55807
+google.com, pub-1929615694373103, RESELLER, f08c47fec0942fa0
+indexexchange.com, 190549, RESELLER, 50b1c356f2c5c8fc
+openx.com, 539496816, RESELLER, 6a698e2ec38604c6
+triplelift.com, 12200, RESELLER, 6c33edb13117fd86
+google.com, pub-5717092533913515, RESELLER, f08c47fec0942fa0 #NPMpartners
+gannett.com, 22597229605, RESELLER
+freewheel.tv, 1064705, RESELLER
+contextweb.com, 561340, RESELLER, 89ff185a4c4e857c
+media.net, 8CUP5F2LD, RESELLER
+media.net, 8CU95X561, RESELLER
+appnexus.com, 9733, RESELLER
+inmobi.com, 64d831e7ed4840ac8ea2283745f07d75, RESELLER, 83e75a7ae333ca9d
+33across.com, 0015a00002y7TWTAA2, RESELLER, bbea06d9c4d2853c #33Across #hb #tag
+supply.colossusssp.com, 332, RESELLER, 6c5b49d96ec1b458
+smartadserver.com, 3630, RESELLER
+loopme.com, 11186, RESELLER, 6c8d5f95897a5a3b
+resetdigital.co, 210, RESELLER
+yieldmo.com, 3286586829842621292, RESELLER
+didna.io, 494n1p17081a, DIRECT
+google.com, pub-3565385483761681, RESELLER, f08c47fec0942fa0 #diDNA_google
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER
+
 #TBC
 ######## Google Publisher ID 26.10.17
 google.com, pub-2557501611105071, DIRECT, f08c47fec0942fa0

--- a/MediaImpact/bild.de/ads.txt
+++ b/MediaImpact/bild.de/ads.txt
@@ -47,6 +47,8 @@ resetdigital.co, 210, RESELLER
 yieldmo.com, 3286586829842621292, RESELLER
 didna.io, 494n1p17081a, DIRECT
 google.com, pub-3565385483761681, RESELLER, f08c47fec0942fa0 #diDNA_google
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER
 
 #accompanying-content #EMEA #Video #Outstream
 pubmatic.com, 163106, RESELLER, 5d62403b186f2ace

--- a/MediaImpact/bz-berlin.de/ads.txt
+++ b/MediaImpact/bz-berlin.de/ads.txt
@@ -190,6 +190,8 @@ resetdigital.co, 210, RESELLER
 yieldmo.com, 3286586829842621292, RESELLER
 didna.io, 494n1p17081a, DIRECT
 google.com, pub-3565385483761681, RESELLER, f08c47fec0942fa0 #diDNA_google
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER
 
 #accompanying-content #EMEA #Video #Outstream
 pubmatic.com, 163106, RESELLER, 5d62403b186f2ace

--- a/MediaImpact/fitbook.de/ads.txt
+++ b/MediaImpact/fitbook.de/ads.txt
@@ -117,3 +117,6 @@ tremorhub.com,1deq6-krwt1,DIRECT,1a4e959a1b50034a
 xandr.com,12548,DIRECT
 yieldlab.net,7568866,DIRECT
 pubmatic.com, 163248,DIRECT
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER
+

--- a/MediaImpact/myhomebook.de/ads.txt
+++ b/MediaImpact/myhomebook.de/ads.txt
@@ -117,3 +117,6 @@ tremorhub.com,1deq6-krwt1,DIRECT,1a4e959a1b50034a
 xandr.com,12548,DIRECT
 yieldlab.net,7568866,DIRECT
 pubmatic.com, 163248,DIRECT
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER
+

--- a/MediaImpact/petbook.de/ads.txt
+++ b/MediaImpact/petbook.de/ads.txt
@@ -117,3 +117,5 @@ tremorhub.com,1deq6-krwt1,DIRECT,1a4e959a1b50034a
 xandr.com,12548,DIRECT
 yieldlab.net,7568866,DIRECT
 pubmatic.com, 163248,DIRECT
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER

--- a/MediaImpact/sportbild.de/ads.txt
+++ b/MediaImpact/sportbild.de/ads.txt
@@ -82,6 +82,34 @@ yieldlab.net, 5798882, RESELLER #instream video by outbrain
 yieldlab.net, 6248161, RESELLER #instream video by outbrain
 yieldlab.net, 6374282, RESELLER #instream video by outbrain
 
+#accompanying-content #Video
+connatix.com, 1428082215386231, DIRECT, 2af98acdee0e81ed
+pubmatic.com, 156592, RESELLER, 5d62403b186f2ace
+pubmatic.com, 163106, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 19564, RESELLER, 0bfd66d529a55807
+google.com, pub-1929615694373103, RESELLER, f08c47fec0942fa0
+indexexchange.com, 190549, RESELLER, 50b1c356f2c5c8fc
+openx.com, 539496816, RESELLER, 6a698e2ec38604c6
+triplelift.com, 12200, RESELLER, 6c33edb13117fd86
+google.com, pub-5717092533913515, RESELLER, f08c47fec0942fa0 #NPMpartners
+gannett.com, 22597229605, RESELLER
+freewheel.tv, 1064705, RESELLER
+contextweb.com, 561340, RESELLER, 89ff185a4c4e857c
+media.net, 8CUP5F2LD, RESELLER
+media.net, 8CU95X561, RESELLER
+appnexus.com, 9733, RESELLER
+inmobi.com, 64d831e7ed4840ac8ea2283745f07d75, RESELLER, 83e75a7ae333ca9d
+33across.com, 0015a00002y7TWTAA2, RESELLER, bbea06d9c4d2853c #33Across #hb #tag
+supply.colossusssp.com, 332, RESELLER, 6c5b49d96ec1b458
+smartadserver.com, 3630, RESELLER
+loopme.com, 11186, RESELLER, 6c8d5f95897a5a3b
+resetdigital.co, 210, RESELLER
+yieldmo.com, 3286586829842621292, RESELLER
+didna.io, 494n1p17081a, DIRECT
+google.com, pub-3565385483761681, RESELLER, f08c47fec0942fa0 #diDNA_google
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER
+
 #Native #Outbrain #Banner #Outstream
 beachfront.com, 14027, RESELLER, e2541279e8e2ca4d # Premium Video Demand
 contextweb.com, 562709, RESELLER, 89ff185a4c4e857c

--- a/MediaImpact/stylebook.de/ads.txt
+++ b/MediaImpact/stylebook.de/ads.txt
@@ -117,3 +117,6 @@ tremorhub.com,1deq6-krwt1,DIRECT,1a4e959a1b50034a
 xandr.com,12548,DIRECT
 yieldlab.net,7568866,DIRECT
 pubmatic.com, 163248,DIRECT
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER
+

--- a/MediaImpact/techbook.de/ads.txt
+++ b/MediaImpact/techbook.de/ads.txt
@@ -117,3 +117,6 @@ tremorhub.com,1deq6-krwt1,DIRECT,1a4e959a1b50034a
 xandr.com,12548,DIRECT
 yieldlab.net,7568866,DIRECT
 pubmatic.com, 163248,DIRECT
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER
+

--- a/MediaImpact/travelbook.de/ads.txt
+++ b/MediaImpact/travelbook.de/ads.txt
@@ -117,3 +117,5 @@ tremorhub.com,1deq6-krwt1,DIRECT,1a4e959a1b50034a
 xandr.com,12548,DIRECT
 yieldlab.net,7568866,DIRECT
 pubmatic.com, 163248,DIRECT
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER

--- a/MediaImpact/welt.de/ads.txt
+++ b/MediaImpact/welt.de/ads.txt
@@ -148,3 +148,6 @@ resetdigital.co, 210, RESELLER
 yieldmo.com, 3286586829842621292, RESELLER
 didna.io, 494n1p17081a, DIRECT
 google.com, pub-3565385483761681, RESELLER, f08c47fec0942fa0 #diDNA_google
+adform.com, 3124, RESELLER
+improvedigital.com, 1845, RESELLER
+


### PR DESCRIPTION
Added Line 50, 51 for Connatix to bild.de ads.txt
Added Line 151 & 152 to welt.de ads.txt for Connatix
Added Line 193 & 194 to bz-berlin ads.txt for Connatix
Added Line 120 & 121 to fitbook.de ads.txt for Connatix
Added Line 120 & 121 to myhomebook.de ads.txt for Connatix
Added Line 120 & 121 to petbook.de ads.txt for Connatix
Added Line 120 & 121 to stylebook.de ads.txt for Connatix
Added Line 120 & 121 to techbook.de ads.txt for Connatix
Added Line 120 & 121 to travelbook.de ads.txt for Connatix
Added Lines 85 - 111 to sportbild.de ads.txt for Connatix Launch
Added Lines 54 - 80 to autobild.de ads.txt for Connatix Launch